### PR TITLE
docs: restore scaffold contract for generated Terragrunt deployments

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -1,43 +1,28 @@
 ##
-# (c) 2025 - Cloud Ops Works LLC - https://cloudops.works/
-#            On GitHub: https://github.com/cloudopsworks
-#            Distributed Under Apache v2.0 License
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Find us on:
+#       GitHub: https://github.com/cloudopsworks
+#       WebSite: https://cloudops.works
+#     Distributed Under Apache v2.0 License
 #
+# Terragrunt Boilerplate Configuration
 variables:
   # Generic Boilerplate Variables Setup
-  - name: organization_name
-    order: 0
-    description: "Organization Name"
-    type: string
-    default: "Organization"
-  - name: organization_unit
-    order: 1
-    description: "Organization Unit"
-    type: string
-    default: "Unit"
-  - name: environment_name
-    order: 2
-    description: "Environment Name"
-    type: string
-    default: "DEV"
-  - name: environment_type
-    order: 3
-    description: "Environment Type"
-    type: string
-    default: "Testing"
-  - name: hub_spoke
-    order: 4
-    description: "Hub and Spoke architecture"
-    type: bool
-    default: false
   - name: is_hub
-    order: 5
+    order: 0
     description: "Is this a hub configuration?"
     type: bool
     default: false
   - name: tags
-    order: 6
+    order: 1
     description: "Tags"
     type: map
     default: {}
   # End - Generic Boilerplate Variables Setup
+
+hooks:
+  after:
+    - command: "git"
+      args: ["add", "terragrunt.hcl", "inputs.yaml", "local-tags.json"]
+      dir: "{{ outputFolder }}"

--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -1,18 +1,139 @@
 # Module configuration
-# Required variables
-{{- range .requiredVariables }}
-{{- if ne .Name "org"}}
-# Description {{ .Description }} , Type: {{ .Type }}
-{{ .Name }}: {{ .DefaultValuePlaceholder }}
-{{- end }}
+# Module-specific inputs only. Terragrunt hierarchy/scaffold supplies org, is_hub, spoke_def, and extra_tags.
 
-{{- end }}
-# Optional variables
-{{- range .optionalVariables }}
-{{- if ne .Name "is_hub" "spoke_def" "extra_args" }}
-# Description {{ .Description }} , Type: {{ .Type }}
-#{{ .Name }}: {{ .DefaultValue }}
-{{- end }}
+name: "" # (Optional) Exact EC2 instance name. Set this or name_prefix. Default: "".
+name_prefix: "" # (Optional) Prefix used to derive the final instance name with the module naming convention. Default: "".
 
-{{- end }}
+instance:
+  create: true # (Optional) Create the EC2 instance resources. Default: true.
+  create_spot: false # (Optional) Launch a Spot instance instead of an on-demand instance. Default: false.
+  ignore_ami_changes: false # (Optional) Ignore subsequent AMI drift after the first create. Default: false.
+  type: "t3.micro" # (Required when instance.create=true) EC2 instance type. Example: "t3.micro". No module default.
+  availability_zone: null # (Optional) Availability Zone for the instance and dedicated host resources. Default: null.
+  hibernation: null # (Optional) Enable EC2 hibernation when the AMI and instance type support it. Default: null.
+  monitoring: null # (Optional) Enable detailed CloudWatch monitoring. Default: null.
+  get_password_data: null # (Optional) Retrieve Windows password data. Default: null.
+  user_data: null # (Optional) Plain-text user data. Default: null.
+  user_data_base64: null # (Optional) Base64-encoded user data. Default: null.
+  user_data_file: null # (Optional) Local file path to base64-encode when using the AMI-ignore workflow. Default: null.
+  user_data_replace_on_change: null # (Optional) Recreate the instance when user data changes. Default: null.
+  source_dest_check: null # (Optional) Enable or disable source/destination checks. Default: null.
+  disable_api_termination: null # (Optional) Protect the instance from API termination. Default: null.
+  disable_api_stop: null # (Optional) Protect the instance from API stop actions. Default: null.
+  instance_initiated_shutdown_behavior: null # (Optional) Behavior after an in-guest shutdown. Valid values: "stop", "terminate". Default: null.
+  placement_group: null # (Optional) Existing placement group name. Default: null.
+  tenancy: null # (Optional) Tenancy model. Valid values: "default", "dedicated", "host". Default: null.
+  host_id: null # (Optional) Existing dedicated host ID to reuse when dedicated_host.enabled=false. Default: null.
+  cpu_credits: null # (Optional) CPU credits mode for burstable families. Valid values: "standard", "unlimited". Default: null.
+  extra_tags: {} # (Optional) Additional tags merged into instance tags. Default: {}.
+  volume_extra_tags: {} # (Optional) Additional tags merged into EBS volume tags. Default: {}.
+  secrets_manager_enabled: true # (Optional) Store generated key material in AWS Secrets Manager when key_pair.create=true. Default: true.
 
+  ami:
+    name: null # (Optional) AMI name lookup. When set, it takes precedence over ami.id. Default: null.
+    id: null # (Optional) Explicit AMI ID. Use this when ami.name is not set. Default: null.
+    architecture: "x86_64" # (Optional) AMI architecture filter for name-based lookups. Common values: "x86_64", "arm64". Default: "x86_64".
+    most_recent: true # (Optional) Select the newest AMI that matches the filters. Default: true.
+    owners: ["self"] # (Optional) AWS account IDs or aliases allowed to own the selected AMI. Default: ["self"].
+    filters: [] # (Optional) Additional aws_ami filters; each item supports name and values. Default: [].
+
+  spot:
+    price: null # (Optional) Maximum Spot price. Default: null.
+    type: "one-time" # (Optional) Spot request type. Valid values: "one-time", "persistent". Default: "one-time".
+    instance_interruption_behavior: null # (Optional) Spot interruption behavior. Valid values: "terminate", "stop", "hibernate". Default: null.
+    valid_until: null # (Optional) RFC3339 expiration timestamp for the Spot request. Default: null.
+
+  dedicated_host:
+    enabled: false # (Optional) Create a dedicated host for non-Spot launches. Default: false.
+    instance_family: null # (Optional) Dedicated host instance family. When null, the module derives it from instance.type. Default: null.
+    host_recovery: null # (Optional) Dedicated host recovery setting. Default: null.
+    auto_placement: null # (Optional) Dedicated host auto placement. Valid values: "on", "off". Default: null.
+
+  key_pair:
+    create: false # (Optional) Generate and register a new AWS key pair. Default: false.
+    name: null # (Optional) Existing or generated key pair name. When create=true and omitted, the module derives the name. Default: null.
+
+  cpu_options:
+    core_count: null # (Optional) Number of CPU cores. Default: null.
+    threads_per_core: null # (Optional) Threads per CPU core. Default: null.
+    amd_sev_snp: null # (Optional) Enable AMD SEV-SNP when supported. Default: null.
+
+  vpc:
+    subnet_id: null # (Required when creating the instance or a managed ENI/security group) Target subnet ID. Default: null.
+    security_group_ids: [] # (Optional) Existing security groups to attach, in addition to a managed security group when enabled. Default: [].
+    associate_public_ip_address: null # (Optional) Assign a public IPv4 address on launch. Default: null.
+    public_eip_id: "" # (Optional) Existing Elastic IP allocation ID to associate after launch when associate_public_ip_address=false. Default: "".
+    private_ip: null # (Optional) Primary private IPv4 address. Default: null.
+    secondary_private_ips: [] # (Optional) Additional private IPv4 addresses. Default: [].
+    ipv6_address_count: null # (Optional) Number of IPv6 addresses to assign. Default: null.
+    ipv6_addresses: [] # (Optional) Explicit IPv6 addresses to assign. Default: [].
+
+  security_group:
+    create: false # (Optional) Create a dedicated security group in the instance subnet VPC. Default: false.
+    rules: {} # (Optional) Map of rule objects. Each rule supports description, type, from_port, to_port, protocol, cidr_blocks, ipv6_cidr_blocks, self, source_security_group, and source_security_group_id. Default: {}.
+
+  network_interface:
+    create: false # (Optional) Create and attach a managed ENI. Default: false.
+    subnet_id: null # (Required when network_interface.create=true) Subnet for the managed ENI. Default: null.
+    private_ips: [] # (Optional) Static private IPv4 addresses for the managed ENI. Default: [].
+    delete_on_termination: null # (Optional) Delete an attached existing ENI on instance termination when create=false. Default: null.
+    network_interface_id: null # (Optional) Existing ENI ID to attach when network_interface.create=false. Default: null.
+
+  root_block_device:
+    volume_size: null # (Optional) Root volume size in GiB. Default: null.
+    volume_type: null # (Optional) Root volume type. Example: "gp3". Default: null.
+    iops: null # (Optional) Root volume provisioned IOPS. Default: null.
+    throughput: null # (Optional) Root volume throughput in MiB/s. Default: null.
+    encrypted: null # (Optional) Encrypt the root volume. Default: null.
+    kms_key_id: null # (Optional) KMS key ID or ARN for root volume encryption. Default: null.
+    delete_on_termination: null # (Optional) Delete the root volume when the instance is terminated. Default: null.
+    tags: {} # (Optional) Additional tags for the root volume. Default: {}.
+
+  ebs:
+    ebs_optimized: null # (Optional) Enable EBS optimization when supported by the instance type. Default: null.
+    block_device: [] # (Optional) Additional EBS volumes. Each item supports device_name and optional delete_on_termination, encrypted, iops, kms_key_id, snapshot_id, volume_size, volume_type, throughput, and tags. Default: [].
+
+  ephemeral_block_device: [] # (Optional) Ephemeral devices. Each item supports device_name and optional virtual_name and no_device. Default: [].
+
+  metadata_options:
+    http_endpoint: null # (Optional) IMDS endpoint state. Valid values: "enabled", "disabled". Default: null.
+    http_put_response_hop_limit: null # (Optional) IMDS hop limit. Default: null.
+    http_tokens: null # (Optional) IMDS token requirement. Valid values: "optional", "required". Default: null.
+    instance_metadata_tags: null # (Optional) Expose tags through IMDS. Valid values: "enabled", "disabled". Default: null.
+
+  private_dns_name_options:
+    hostname_type: null # (Optional) Private DNS hostname type. Valid values: "ip-name", "resource-name". Default: null.
+    enable_resource_name_dns_a_record: null # (Optional) Publish A record for the resource name. Default: null.
+    enable_resource_name_dns_aaaa_record: null # (Optional) Publish AAAA record for the resource name. Default: null.
+
+  maintenance_options:
+    auto_recovery: null # (Optional) EC2 auto recovery behavior. Valid values: "default", "disabled". Default: null.
+
+  enclave_options:
+    enabled: null # (Optional) Enable Nitro Enclaves. Default: null.
+
+  capacity_reservation_specification:
+    capacity_reservation_preference: null # (Optional) Capacity reservation preference. Valid values: "open", "none". Default: null.
+    capacity_reservation_target:
+      capacity_reservation_id: null # (Optional) Capacity reservation ID. Default: null.
+      capacity_reservation_resource_group_arn: null # (Optional) Capacity reservation resource group ARN. Default: null.
+
+  backup:
+    enabled: false # (Optional) Apply AWS Backup tagging. Default: false.
+    only_tag: true # (Optional) Only tag the instance for backup selection. Default: true.
+    schedule: "daily" # (Optional) Backup schedule tag. Valid values: "hourly", "daily", "weekly", "monthly". Default: "daily".
+
+timeouts:
+  create: null # (Optional) Terraform create timeout, for example "30m". Default: null.
+  update: null # (Optional) Terraform update timeout, for example "30m". Default: null.
+  delete: null # (Optional) Terraform delete timeout, for example "30m". Default: null.
+
+iam:
+  create: true # (Optional) Create an IAM role and instance profile for the instance. Default: true.
+  instance_profile: null # (Optional) Existing IAM instance profile to use when iam.create=false. Default: null.
+  path: null # (Optional) IAM path for created role and instance profile. Default: null.
+  role_description: null # (Optional) Custom description for the created IAM role. Default: null.
+  permissions_boundary: null # (Optional) IAM permissions boundary ARN for the created role. Default: null.
+  extra_tags: {} # (Optional) Additional tags for IAM resources. Default: {}.
+  role_policies: {} # (Optional) Map of managed policy attachments where the value is a policy ARN. Default: {}.
+  policies: [] # (Optional) Inline IAM policies to create. Each item supports name and statements; statements support sid, effect, actions, resources, principals { type, identifiers }, and conditions { test, variable, values }. Default: [].

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -1,5 +1,4 @@
 locals {
-  {{- if .hub_spoke }}
   local_vars  = yamldecode(file("./inputs.yaml"))
   spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
   region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
@@ -19,21 +18,10 @@ locals {
     local.spoke_tags,
     local.local_tags
   )
-  {{- else }}
-  local_vars  = yamldecode(file("./inputs.yaml"))
-  global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
-  global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
-  local_tags  = jsondecode(file("./local-tags.json"))
-
-  tags = merge(
-    local.global_tags,
-    local.local_tags
-  )
-  {{- end }}
 }
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path = find_in_parent_folders("{{ .RootFileName }}")
 }
 
 terraform {
@@ -41,27 +29,16 @@ terraform {
 }
 
 inputs = {
-  # org = {
-  #   organization_name = local.env_vars.org.organization_name
-  #   organization_unit = local.env_vars.org.organization_unit
-  #   environment_name  = local.env_vars.org.environment_name
-  #   environment_type  = local.env_vars.org.environment_type
-  # }
-  org = local.env_vars.org
-  {{- if .hub_spoke }}
-  is_hub = {{ .is_hub }}
-  spoke_def = local.spoke_vars.spoke_def
-  {{- end}}
-  ## Required
+  is_hub     = {{ .is_hub }}
+  org        = local.env_vars.org
+  spoke_def  = local.spoke_vars.spoke_def
   {{- range .requiredVariables }}
   {{- if ne .Name "org" }}
-  {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
+  {{ .Name }} = local.local_vars.{{ .Name }}
   {{- end }}
   {{- end }}
-
-  ## Optional
   {{- range .optionalVariables }}
-  {{- if ne .Name "extra_tags" "is_hub" "spoke_def" "org" }}
+  {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org") }}
   {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
   {{- end }}
   {{- end }}

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.11.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![cloudopsworks][logo]](https://cloudopsworks.co/)
 
-# Terraform AWS EC2 Instance
+# Terraform AWS EC2 Instance [![Latest Release](https://img.shields.io/github/release/cloudopsworks/terraform-module-aws-ec2-instances.svg?style=for-the-badge)](https://github.com/cloudopsworks/terraform-module-aws-ec2-instances/releases/latest) [![Last Updated](https://img.shields.io/github/last-commit/cloudopsworks/terraform-module-aws-ec2-instances.svg?style=for-the-badge)](https://github.com/cloudopsworks/terraform-module-aws-ec2-instances/commits)
 
 
 Opinionated Terraform module for provisioning and managing Amazon EC2 instances at scale.
@@ -63,289 +63,242 @@ auditability, and repeatable deployments across environments with minimal boiler
 Instead pin to the release tag (e.g. `?ref=vX.Y.Z`) of one of our [latest releases](https://github.com/cloudopsworks/terraform-module-aws-ec2-instances/releases).
 
 
-To incorporate this module, reference it with Terragrunt and follow the .boilerplate structure in the "develop" branch of this repository.
+Create a deployment directory, scaffold the module, edit the generated inputs, and apply it with Terragrunt.
 
-Basic steps to use the module:
-1. Install Terraform (v1.0 or higher) and Terragrunt.
-2. Create or update your Terragrunt configuration files using the .boilerplate patterns.
-3. Provide inputs: org (required), name or name_prefix, and the instance map (see schema below). Optionally adjust iam/timeouts.
-   - By default, iam.create = true and the module creates an IAM role and instance profile.
-     To reuse an existing profile instead, set iam.create = false and set iam.instance_profile.
-   - For Spot instances, set instance.create_spot = true and optionally configure instance.spot options.
-   - Configure the AWS provider (e.g., region) in your stack.
-4. Run terragrunt init to initialize your working directory.
-5. Run terragrunt plan to view resource changes.
-6. Run terragrunt apply to create the resources.
+```sh
+# 1. Create and enter the target deployment directory
+mkdir -p <environment>/<region>/<spoke>/ec2-instance
+cd <environment>/<region>/<spoke>/ec2-instance
 
-Available Variables:
+# 2. Scaffold the module (do NOT use --working-dir)
+terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-ec2-instances
 
-name: (string, optional)
-  - The name of the EC2 Instance
-  - Default: ""
+# 3. Edit inputs.yaml with deployment-specific values
+#    (all keys and comments are pre-populated from .boilerplate/inputs.yaml)
+vi inputs.yaml
 
-name_prefix: (string, optional)
-  - The name prefix of the EC2 Instance
-  - Default: ""
+# 4. Review the execution plan
+terragrunt plan
 
-org: (object, required)
-  - Organization and environment context used for consistent naming and tagging
-  - Keys:
-    - organization_name (string)
-    - organization_unit (string)
-    - environment_type (string)
-    - environment_name (string)
+# 5. Apply
+terragrunt apply
+```
 
-is_hub: (bool, optional)
-  - Whether this stack represents a HUB configuration
-  - Default: false
+The scaffolded `inputs.yaml` contains only module-specific variables. The Terragrunt hierarchy provides `org`, `is_hub`, `spoke_def`, and merged `extra_tags` automatically.
 
-spoke_def: (string, optional)
-  - Spoke identifier used in the computed system name
-  - Default: "001"
+Generated `inputs.yaml`:
 
-extra_tags: (map(string), optional)
-  - Additional tags to merge with common tags and apply to resources
-  - Default: {}
+```yaml
+# Module configuration
+# Module-specific inputs only. Terragrunt hierarchy/scaffold supplies org, is_hub, spoke_def, and extra_tags.
 
-instance: (map, optional)
-  Complex configuration for EC2 instance. Supports following structure:
-  ```yaml
-  instance:
-    create: true | false     # defaults to true
-    create_spot: true | false # defaults to false
-    ignore_ami_changes: true | false # defaults to false
-    spot:
-      price: "0.02"                        # optional max price; omit to use current market
-      type: "one-time"                     # "one-time" | "persistent" (default: "one-time")
-      wait_for_fulfillment: true | false   # defaults to true
-      launch_group: "group-name"           # optional
-      block_duration_minutes: 60           # optional
-      instance_interruption_behavior: "terminate" | "stop" | "hibernate"
-      valid_from: "2025-01-01T00:00:00Z"   # optional
-      valid_until: "2025-12-31T23:59:59Z"  # optional
-    dedicated_host:           # launch into a dedicated host when enabled (not for spot)
-      enabled: true | false   # defaults to false
-      instance_family: "c7i"  # optional; else uses instance.type
-      host_recovery: true | false
-      auto_placement: "on" | "off"
-    ami:
-      name: "ami-name"        # optional; if provided, ami.id is ignored
-      architecture: "x86_64" | "arm64" # defaults to "x86_64"
-      id: "ami-id"            # optional; used when ami.name is not provided
-      most_recent: true | false # defaults to true
-      owners: ["self"]        # defaults to ["self"]
-      filters:                # defaults to []
-        - name: "filter-name"
-          values: ["filter-value"]
-    type: "t2.micro"          # defaults to "t2.micro"
-    hibernation: true | false
-    user_data: "user-data"
-    user_data_base64: "user-data-base64"
-    user_data_replace_on_change: true | false
-    cpu_options:
-      core_count: 1
-      threads_per_core: 1
-      amd_sev_snp: true | false
-    availability_zone: "us-east-1a"
-    key_pair:
-      create: true | false    # defaults to false (creates and tags a new key)
-      name: "existing-key-name" # if create=false, use this existing key
-    monitoring: true | false
-    get_password_data: true | false
-    vpc:
-      security_group_ids: ["sg-12345678"]
-      associate_public_ip_address: true | false
-      subnet_id: "subnet-id"
-      private_ip: "private-ip"
-      secondary_private_ips: ["secondary-private-ip"]
-      ipv6_address_count: 1
-      ipv6_addresses: ["ipv6-address"]
-    security_group:
-      create: true | false    # defaults to false; when true, module creates a SG in the subnet's VPC
-      rules:                  # optional map of rules applied when create=true
-        ssh:
-          type: "ingress"
-          from_port: 22
-          to_port: 22
-          protocol: "tcp"
-          cidr_blocks: ["0.0.0.0/0"]
-    network_interface:
-      create: true | false    # defaults to false
-      subnet_id: "subnet-id"  # required when create=true
-      private_ips: ["private-ip"]
-      delete_on_termination: true | false
-      network_interface_id: "eni-id"
-    # For Spot instances, use a list of network_interface blocks:
-    # network_interface:
-    #   - device_index: 0
-    #     network_interface_id: "eni-id"
-    #     delete_on_termination: true | false # defaults to true
-    root_block_device:
-      - volume_size: 8
-        volume_type: "gp3"
-        iops: 3000
-        throughput: 125
-        encrypted: true | false
-        kms_key_id: "kms-key-id"
-        delete_on_termination: true | false
-        tags: { "Name": "root-volume" }
-    ebs:
-      ebs_optimized: true | false
-      block_device:
-        - device_name: "/dev/xvdb"
-          volume_size: 8
-          volume_type: "gp3"
-          iops: 3000
-          throughput: 125
-          encrypted: true
-          kms_key_id: "kms-key-id"
-          snapshot_id: "snap-1234"
-          delete_on_termination: true
-          tags: { "Name": "data-volume" }
-    ephemeral_block_device:
-      - device_name: "/dev/sdh"
-        virtual_name: "ephemeral0"
-        no_device: true
-    metadata_options:
-      http_endpoint: "enabled" | "disabled"    # defaults to "enabled"
-      http_tokens: "required" | "optional"     # defaults to "optional"
-      http_put_response_hop_limit: 1
-      instance_metadata_tags: "enabled" | "disabled" # defaults to "enabled"
-    private_dns_name_options:
-      hostname_type: "ip-name" | "resource-name"
-      enable_resource_name_dns_a_record: true | false
-      enable_resource_name_dns_aaaa_record: true | false
-    maintenance_options:
-      auto_recovery: "default" | "disabled"
-    enclave_options:
-      enabled: true | false
-    cpu_credits: "standard" | "unlimited"      # for T-family instances only
-    capacity_reservation_specification:
-      capacity_reservation_preference: "open" | "none"
-      capacity_reservation_target:
-        capacity_reservation_id: "cr-0123456789abcdef0"
-        capacity_reservation_resource_group_arn: "arn:aws:resource-groups:..."
-    source_dest_check: true | false
-    disable_api_termination: true | false
-    disable_api_stop: true | false
-    instance_initiated_shutdown_behavior: "stop" | "terminate"
-    placement_group: "placement-group"
-    tenancy: "default" | "dedicated"
-    host_id: "h-0123456789abcdef0"             # optional; used when attaching to an existing dedicated host
-    backup:
-      enabled: true | false                     # defaults to false
-      only_tag: true | false                    # defaults to true
-      schedule: hourly | daily | weekly | monthly # defaults to daily; used for the 'aws-backup-schedule' tag
-    extra_tags: { "env": "dev" }                # additional tags for the instance
-    volume_extra_tags: { "tier": "gold" }       # additional tags for EBS volumes
-  ```
+name: "" # (Optional) Exact EC2 instance name. Set this or name_prefix. Default: "".
+name_prefix: "" # (Optional) Prefix used to derive the final instance name with the module naming convention. Default: "".
 
-timeouts: (map, optional)
-  - The timeouts configuration for the EC2 Instance
-  - Default: {}
+instance:
+  create: true # (Optional) Create the EC2 instance resources. Default: true.
+  create_spot: false # (Optional) Launch a Spot instance instead of an on-demand instance. Default: false.
+  ignore_ami_changes: false # (Optional) Ignore subsequent AMI drift after the first create. Default: false.
+  type: "t3.micro" # (Required when instance.create=true) EC2 instance type. Example: "t3.micro". No module default.
+  availability_zone: null # (Optional) Availability Zone for the instance and dedicated host resources. Default: null.
+  hibernation: null # (Optional) Enable EC2 hibernation when the AMI and instance type support it. Default: null.
+  monitoring: null # (Optional) Enable detailed CloudWatch monitoring. Default: null.
+  get_password_data: null # (Optional) Retrieve Windows password data. Default: null.
+  user_data: null # (Optional) Plain-text user data. Default: null.
+  user_data_base64: null # (Optional) Base64-encoded user data. Default: null.
+  user_data_file: null # (Optional) Local file path to base64-encode when using the AMI-ignore workflow. Default: null.
+  user_data_replace_on_change: null # (Optional) Recreate the instance when user data changes. Default: null.
+  source_dest_check: null # (Optional) Enable or disable source/destination checks. Default: null.
+  disable_api_termination: null # (Optional) Protect the instance from API termination. Default: null.
+  disable_api_stop: null # (Optional) Protect the instance from API stop actions. Default: null.
+  instance_initiated_shutdown_behavior: null # (Optional) Behavior after an in-guest shutdown. Valid values: "stop", "terminate". Default: null.
+  placement_group: null # (Optional) Existing placement group name. Default: null.
+  tenancy: null # (Optional) Tenancy model. Valid values: "default", "dedicated", "host". Default: null.
+  host_id: null # (Optional) Existing dedicated host ID to reuse when dedicated_host.enabled=false. Default: null.
+  cpu_credits: null # (Optional) CPU credits mode for burstable families. Valid values: "standard", "unlimited". Default: null.
+  extra_tags: {} # (Optional) Additional tags merged into instance tags. Default: {}.
+  volume_extra_tags: {} # (Optional) Additional tags merged into EBS volume tags. Default: {}.
+  secrets_manager_enabled: true # (Optional) Store generated key material in AWS Secrets Manager when key_pair.create=true. Default: true.
 
-iam: (map, optional)
-  IAM configuration for the EC2 instance profile:
-  ```yaml
-  iam:
-    create: true | false                 # defaults to true; when true module creates role + instance profile
-    path: "/service-role/"              # optional IAM path
-    role_description: "IAM Instance Role <name>" # optional description
-    permissions_boundary: "arn:aws:iam::123456789012:policy/BoundaryPolicy" # optional
-    extra_tags: { "team": "platform" } # optional tags for IAM resources
-    role_policies:                       # optional map (name => policy ARN) to attach to the role
-      ssm: "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-    instance_profile: "existing-profile" # used only when create=false to use an existing instance profile
-  ```
+  ami:
+    name: null # (Optional) AMI name lookup. When set, it takes precedence over ami.id. Default: null.
+    id: null # (Optional) Explicit AMI ID. Use this when ami.name is not set. Default: null.
+    architecture: "x86_64" # (Optional) AMI architecture filter for name-based lookups. Common values: "x86_64", "arm64". Default: "x86_64".
+    most_recent: true # (Optional) Select the newest AMI that matches the filters. Default: true.
+    owners: ["self"] # (Optional) AWS account IDs or aliases allowed to own the selected AMI. Default: ["self"].
+    filters: [] # (Optional) Additional aws_ami filters; each item supports name and values. Default: [].
 
-Example of a Terragrunt configuration referencing this module (terragrunt.hcl):
+  spot:
+    price: null # (Optional) Maximum Spot price. Default: null.
+    type: "one-time" # (Optional) Spot request type. Valid values: "one-time", "persistent". Default: "one-time".
+    instance_interruption_behavior: null # (Optional) Spot interruption behavior. Valid values: "terminate", "stop", "hibernate". Default: null.
+    valid_until: null # (Optional) RFC3339 expiration timestamp for the Spot request. Default: null.
+
+  dedicated_host:
+    enabled: false # (Optional) Create a dedicated host for non-Spot launches. Default: false.
+    instance_family: null # (Optional) Dedicated host instance family. When null, the module derives it from instance.type. Default: null.
+    host_recovery: null # (Optional) Dedicated host recovery setting. Default: null.
+    auto_placement: null # (Optional) Dedicated host auto placement. Valid values: "on", "off". Default: null.
+
+  key_pair:
+    create: false # (Optional) Generate and register a new AWS key pair. Default: false.
+    name: null # (Optional) Existing or generated key pair name. When create=true and omitted, the module derives the name. Default: null.
+
+  cpu_options:
+    core_count: null # (Optional) Number of CPU cores. Default: null.
+    threads_per_core: null # (Optional) Threads per CPU core. Default: null.
+    amd_sev_snp: null # (Optional) Enable AMD SEV-SNP when supported. Default: null.
+
+  vpc:
+    subnet_id: null # (Required when creating the instance or a managed ENI/security group) Target subnet ID. Default: null.
+    security_group_ids: [] # (Optional) Existing security groups to attach, in addition to a managed security group when enabled. Default: [].
+    associate_public_ip_address: null # (Optional) Assign a public IPv4 address on launch. Default: null.
+    public_eip_id: "" # (Optional) Existing Elastic IP allocation ID to associate after launch when associate_public_ip_address=false. Default: "".
+    private_ip: null # (Optional) Primary private IPv4 address. Default: null.
+    secondary_private_ips: [] # (Optional) Additional private IPv4 addresses. Default: [].
+    ipv6_address_count: null # (Optional) Number of IPv6 addresses to assign. Default: null.
+    ipv6_addresses: [] # (Optional) Explicit IPv6 addresses to assign. Default: [].
+
+  security_group:
+    create: false # (Optional) Create a dedicated security group in the instance subnet VPC. Default: false.
+    rules: {} # (Optional) Map of rule objects. Each rule supports description, type, from_port, to_port, protocol, cidr_blocks, ipv6_cidr_blocks, self, source_security_group, and source_security_group_id. Default: {}.
+
+  network_interface:
+    create: false # (Optional) Create and attach a managed ENI. Default: false.
+    subnet_id: null # (Required when network_interface.create=true) Subnet for the managed ENI. Default: null.
+    private_ips: [] # (Optional) Static private IPv4 addresses for the managed ENI. Default: [].
+    delete_on_termination: null # (Optional) Delete an attached existing ENI on instance termination when create=false. Default: null.
+    network_interface_id: null # (Optional) Existing ENI ID to attach when network_interface.create=false. Default: null.
+
+  root_block_device:
+    volume_size: null # (Optional) Root volume size in GiB. Default: null.
+    volume_type: null # (Optional) Root volume type. Example: "gp3". Default: null.
+    iops: null # (Optional) Root volume provisioned IOPS. Default: null.
+    throughput: null # (Optional) Root volume throughput in MiB/s. Default: null.
+    encrypted: null # (Optional) Encrypt the root volume. Default: null.
+    kms_key_id: null # (Optional) KMS key ID or ARN for root volume encryption. Default: null.
+    delete_on_termination: null # (Optional) Delete the root volume when the instance is terminated. Default: null.
+    tags: {} # (Optional) Additional tags for the root volume. Default: {}.
+
+  ebs:
+    ebs_optimized: null # (Optional) Enable EBS optimization when supported by the instance type. Default: null.
+    block_device: [] # (Optional) Additional EBS volumes. Each item supports device_name and optional delete_on_termination, encrypted, iops, kms_key_id, snapshot_id, volume_size, volume_type, throughput, and tags. Default: [].
+
+  ephemeral_block_device: [] # (Optional) Ephemeral devices. Each item supports device_name and optional virtual_name and no_device. Default: [].
+
+  metadata_options:
+    http_endpoint: null # (Optional) IMDS endpoint state. Valid values: "enabled", "disabled". Default: null.
+    http_put_response_hop_limit: null # (Optional) IMDS hop limit. Default: null.
+    http_tokens: null # (Optional) IMDS token requirement. Valid values: "optional", "required". Default: null.
+    instance_metadata_tags: null # (Optional) Expose tags through IMDS. Valid values: "enabled", "disabled". Default: null.
+
+  private_dns_name_options:
+    hostname_type: null # (Optional) Private DNS hostname type. Valid values: "ip-name", "resource-name". Default: null.
+    enable_resource_name_dns_a_record: null # (Optional) Publish A record for the resource name. Default: null.
+    enable_resource_name_dns_aaaa_record: null # (Optional) Publish AAAA record for the resource name. Default: null.
+
+  maintenance_options:
+    auto_recovery: null # (Optional) EC2 auto recovery behavior. Valid values: "default", "disabled". Default: null.
+
+  enclave_options:
+    enabled: null # (Optional) Enable Nitro Enclaves. Default: null.
+
+  capacity_reservation_specification:
+    capacity_reservation_preference: null # (Optional) Capacity reservation preference. Valid values: "open", "none". Default: null.
+    capacity_reservation_target:
+      capacity_reservation_id: null # (Optional) Capacity reservation ID. Default: null.
+      capacity_reservation_resource_group_arn: null # (Optional) Capacity reservation resource group ARN. Default: null.
+
+  backup:
+    enabled: false # (Optional) Apply AWS Backup tagging. Default: false.
+    only_tag: true # (Optional) Only tag the instance for backup selection. Default: true.
+    schedule: "daily" # (Optional) Backup schedule tag. Valid values: "hourly", "daily", "weekly", "monthly". Default: "daily".
+
+timeouts:
+  create: null # (Optional) Terraform create timeout, for example "30m". Default: null.
+  update: null # (Optional) Terraform update timeout, for example "30m". Default: null.
+  delete: null # (Optional) Terraform delete timeout, for example "30m". Default: null.
+
+iam:
+  create: true # (Optional) Create an IAM role and instance profile for the instance. Default: true.
+  instance_profile: null # (Optional) Existing IAM instance profile to use when iam.create=false. Default: null.
+  path: null # (Optional) IAM path for created role and instance profile. Default: null.
+  role_description: null # (Optional) Custom description for the created IAM role. Default: null.
+  permissions_boundary: null # (Optional) IAM permissions boundary ARN for the created role. Default: null.
+  extra_tags: {} # (Optional) Additional tags for IAM resources. Default: {}.
+  role_policies: {} # (Optional) Map of managed policy attachments where the value is a policy ARN. Default: {}.
+  policies: [] # (Optional) Inline IAM policies to create. Each item supports name and statements; statements support sid, effect, actions, resources, principals { type, identifiers }, and conditions { test, variable, values }. Default: [].
+```
+
+Generated `terragrunt.hcl`:
+
 ```hcl
+locals {
+  local_vars  = yamldecode(file("./inputs.yaml"))
+  spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
+  region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
+  env_vars    = yamldecode(file(find_in_parent_folders("env-inputs.yaml")))
+  global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
+
+  local_tags  = jsondecode(file("./local-tags.json"))
+  spoke_tags  = jsondecode(file(find_in_parent_folders("spoke-tags.json")))
+  region_tags = jsondecode(file(find_in_parent_folders("region-tags.json")))
+  env_tags    = jsondecode(file(find_in_parent_folders("env-tags.json")))
+  global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
+
+  tags = merge(
+    local.global_tags,
+    local.env_tags,
+    local.region_tags,
+    local.spoke_tags,
+    local.local_tags
+  )
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
 terraform {
-  source = "git::https://github.com/cloudopsworks/terraform-module-aws-ec2-instances.git//?ref=develop"
+  source = "github.com/cloudopsworks/terraform-module-aws-ec2-instances"
 }
 
 inputs = {
-  org = {
-    organization_name = "acme"
-    organization_unit = "platform"
-    environment_type  = "nonprod"
-    environment_name  = "dev"
-  }
-
-  name = "my-instance"
-
-  instance = {
-    create = true
-    type   = "t3.micro"
-
-    ami = {
-      name   = "my-custom-ami"
-      owners = ["self"]
-    }
-
-    key_pair = {
-      create = false
-      name   = "my-existing-key"
-    }
-
-    vpc = {
-      subnet_id          = "subnet-123456"
-      security_group_ids = ["sg-123456"]
-    }
-
-    # Optionally let module create and manage a security group with rules:
-    # security_group = {
-    #   create = true
-    #   rules = {
-    #     ssh = {
-    #       type        = "ingress"
-    #       from_port   = 22
-    #       to_port     = 22
-    #       protocol    = "tcp"
-    #       cidr_blocks = ["0.0.0.0/0"]
-    #     }
-    #   }
-    # }
-  }
-
-  # By default, the module creates an IAM role and instance profile (iam.create = true).
-  # To use an existing instance profile instead:
-  iam = {
-    create           = false
-    instance_profile = "my-existing-profile"
-  }
+  is_hub      = false
+  org         = local.env_vars.org
+  spoke_def   = local.spoke_vars.spoke_def
+  name        = try(local.local_vars.name, "")
+  name_prefix = try(local.local_vars.name_prefix, "")
+  instance    = try(local.local_vars.instance, {})
+  timeouts    = try(local.local_vars.timeouts, {})
+  iam         = try(local.local_vars.iam, {})
+  extra_tags  = local.tags
 }
 ```
 
 ## Quick Start
 
-1. Clone or fork the repository to review the .boilerplate templates under the "develop" branch.
-2. Adapt the relevant Terragrunt configuration files for your own environment by referencing this module.
-3. Initialize your workspace using terragrunt init.
-4. Review proposed infrastructure changes by running terragrunt plan.
-5. Finally, configure and deploy your EC2 instances with terragrunt apply.
+1. From your environment stack, create a directory for the EC2 deployment.
+2. Run `terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-ec2-instances` inside that directory.
+3. Fill in `inputs.yaml`, making sure `instance.type`, AMI selection, and subnet details are set.
+4. Run `terragrunt plan` and review the proposed EC2, IAM, networking, and storage resources.
+5. Apply with `terragrunt apply` once the plan matches the desired deployment.
 
 
 ## Examples
 
-Here are sample use cases you can adapt in the .boilerplate files on the "develop" branch:
+Common deployment patterns for this module include:
 
-1. Single Development Instance
-   - Minimal inputs to spin up a small on-demand instance for dev/testing.
-
-2. Spot Instance for Cost Optimization
-   - Set instance.create_spot = true to request spot capacity with the same configuration.
-
-3. Dedicated Host Placement
-   - Set instance.dedicated_host.enabled = true to launch on a dedicated host (supported for the type). Optionally set instance.dedicated_host.instance_family or use host_id to attach to an existing host.
-
-4. Private Subnet Deployment
-   - Provide instance.vpc.subnet_id and security_group_ids; omit public IP or set associate_public_ip_address = false.
-
-5. Custom Storage and Metadata
-   - Use instance.root_block_device or instance.ebs.block_device for volumes, and instance.metadata_options to enforce IMDSv2.
-
-For more Terragrunt-based examples and structural hints, see the .boilerplate directory in the "develop" branch.
+1. **Small on-demand instance**
+   - Set `instance.type`, choose `ami.name` or `ami.id`, and provide `instance.vpc.subnet_id`.
+2. **Spot capacity for cost-sensitive workloads**
+   - Set `instance.create_spot = true` and tune `instance.spot.price`, `instance.spot.type`, and `instance.spot.instance_interruption_behavior`.
+3. **Managed access layer**
+   - Enable `instance.key_pair.create`, keep `instance.secrets_manager_enabled = true`, and add `iam.role_policies` such as `AmazonSSMManagedInstanceCore`.
+4. **Dedicated host placement**
+   - Set `instance.dedicated_host.enabled = true` for non-Spot launches, or provide `instance.host_id` to reuse an existing host.
+5. **Private subnet with controlled ingress**
+   - Set `instance.vpc.associate_public_ip_address = false`, attach existing security groups through `instance.vpc.security_group_ids`, or enable `instance.security_group.create` and define explicit rules.
 
 
 
@@ -373,8 +326,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.11.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -1,6 +1,14 @@
 name: Terraform AWS EC2 Instance
 #logo: logo/logo.jpg
 
+badges:
+  - name: Latest Release
+    image: https://img.shields.io/github/release/cloudopsworks/terraform-module-aws-ec2-instances.svg?style=for-the-badge
+    url: https://github.com/cloudopsworks/terraform-module-aws-ec2-instances/releases/latest
+  - name: Last Updated
+    image: https://img.shields.io/github/last-commit/cloudopsworks/terraform-module-aws-ec2-instances.svg?style=for-the-badge
+    url: https://github.com/cloudopsworks/terraform-module-aws-ec2-instances/commits
+
 license: "APACHE2"
 
 copyrights:
@@ -30,288 +38,241 @@ introduction: |-
 
 # How to use this project
 usage: |-
-  To incorporate this module, reference it with Terragrunt and follow the .boilerplate structure in the "develop" branch of this repository.
+  Create a deployment directory, scaffold the module, edit the generated inputs, and apply it with Terragrunt.
   
-  Basic steps to use the module:
-  1. Install Terraform (v1.0 or higher) and Terragrunt.
-  2. Create or update your Terragrunt configuration files using the .boilerplate patterns.
-  3. Provide inputs: org (required), name or name_prefix, and the instance map (see schema below). Optionally adjust iam/timeouts.
-     - By default, iam.create = true and the module creates an IAM role and instance profile.
-       To reuse an existing profile instead, set iam.create = false and set iam.instance_profile.
-     - For Spot instances, set instance.create_spot = true and optionally configure instance.spot options.
-     - Configure the AWS provider (e.g., region) in your stack.
-  4. Run terragrunt init to initialize your working directory.
-  5. Run terragrunt plan to view resource changes.
-  6. Run terragrunt apply to create the resources.
+  ```sh
+  # 1. Create and enter the target deployment directory
+  mkdir -p <environment>/<region>/<spoke>/ec2-instance
+  cd <environment>/<region>/<spoke>/ec2-instance
   
-  Available Variables:
-
-  name: (string, optional)
-    - The name of the EC2 Instance
-    - Default: ""
-
-  name_prefix: (string, optional)
-    - The name prefix of the EC2 Instance
-    - Default: ""
-
-  org: (object, required)
-    - Organization and environment context used for consistent naming and tagging
-    - Keys:
-      - organization_name (string)
-      - organization_unit (string)
-      - environment_type (string)
-      - environment_name (string)
-
-  is_hub: (bool, optional)
-    - Whether this stack represents a HUB configuration
-    - Default: false
-
-  spoke_def: (string, optional)
-    - Spoke identifier used in the computed system name
-    - Default: "001"
-
-  extra_tags: (map(string), optional)
-    - Additional tags to merge with common tags and apply to resources
-    - Default: {}
-
-  instance: (map, optional)
-    Complex configuration for EC2 instance. Supports following structure:
-    ```yaml
-    instance:
-      create: true | false     # defaults to true
-      create_spot: true | false # defaults to false
-      ignore_ami_changes: true | false # defaults to false
-      spot:
-        price: "0.02"                        # optional max price; omit to use current market
-        type: "one-time"                     # "one-time" | "persistent" (default: "one-time")
-        wait_for_fulfillment: true | false   # defaults to true
-        launch_group: "group-name"           # optional
-        block_duration_minutes: 60           # optional
-        instance_interruption_behavior: "terminate" | "stop" | "hibernate"
-        valid_from: "2025-01-01T00:00:00Z"   # optional
-        valid_until: "2025-12-31T23:59:59Z"  # optional
-      dedicated_host:           # launch into a dedicated host when enabled (not for spot)
-        enabled: true | false   # defaults to false
-        instance_family: "c7i"  # optional; else uses instance.type
-        host_recovery: true | false
-        auto_placement: "on" | "off"
-      ami:
-        name: "ami-name"        # optional; if provided, ami.id is ignored
-        architecture: "x86_64" | "arm64" # defaults to "x86_64"
-        id: "ami-id"            # optional; used when ami.name is not provided
-        most_recent: true | false # defaults to true
-        owners: ["self"]        # defaults to ["self"]
-        filters:                # defaults to []
-          - name: "filter-name"
-            values: ["filter-value"]
-      type: "t2.micro"          # defaults to "t2.micro"
-      hibernation: true | false
-      user_data: "user-data"
-      user_data_base64: "user-data-base64"
-      user_data_replace_on_change: true | false
-      cpu_options:
-        core_count: 1
-        threads_per_core: 1
-        amd_sev_snp: true | false
-      availability_zone: "us-east-1a"
-      key_pair:
-        create: true | false    # defaults to false (creates and tags a new key)
-        name: "existing-key-name" # if create=false, use this existing key
-      monitoring: true | false
-      get_password_data: true | false
-      vpc:
-        security_group_ids: ["sg-12345678"]
-        associate_public_ip_address: true | false
-        subnet_id: "subnet-id"
-        private_ip: "private-ip"
-        secondary_private_ips: ["secondary-private-ip"]
-        ipv6_address_count: 1
-        ipv6_addresses: ["ipv6-address"]
-      security_group:
-        create: true | false    # defaults to false; when true, module creates a SG in the subnet's VPC
-        rules:                  # optional map of rules applied when create=true
-          ssh:
-            type: "ingress"
-            from_port: 22
-            to_port: 22
-            protocol: "tcp"
-            cidr_blocks: ["0.0.0.0/0"]
-      network_interface:
-        create: true | false    # defaults to false
-        subnet_id: "subnet-id"  # required when create=true
-        private_ips: ["private-ip"]
-        delete_on_termination: true | false
-        network_interface_id: "eni-id"
-      # For Spot instances, use a list of network_interface blocks:
-      # network_interface:
-      #   - device_index: 0
-      #     network_interface_id: "eni-id"
-      #     delete_on_termination: true | false # defaults to true
-      root_block_device:
-        - volume_size: 8
-          volume_type: "gp3"
-          iops: 3000
-          throughput: 125
-          encrypted: true | false
-          kms_key_id: "kms-key-id"
-          delete_on_termination: true | false
-          tags: { "Name": "root-volume" }
-      ebs:
-        ebs_optimized: true | false
-        block_device:
-          - device_name: "/dev/xvdb"
-            volume_size: 8
-            volume_type: "gp3"
-            iops: 3000
-            throughput: 125
-            encrypted: true
-            kms_key_id: "kms-key-id"
-            snapshot_id: "snap-1234"
-            delete_on_termination: true
-            tags: { "Name": "data-volume" }
-      ephemeral_block_device:
-        - device_name: "/dev/sdh"
-          virtual_name: "ephemeral0"
-          no_device: true
-      metadata_options:
-        http_endpoint: "enabled" | "disabled"    # defaults to "enabled"
-        http_tokens: "required" | "optional"     # defaults to "optional"
-        http_put_response_hop_limit: 1
-        instance_metadata_tags: "enabled" | "disabled" # defaults to "enabled"
-      private_dns_name_options:
-        hostname_type: "ip-name" | "resource-name"
-        enable_resource_name_dns_a_record: true | false
-        enable_resource_name_dns_aaaa_record: true | false
-      maintenance_options:
-        auto_recovery: "default" | "disabled"
-      enclave_options:
-        enabled: true | false
-      cpu_credits: "standard" | "unlimited"      # for T-family instances only
-      capacity_reservation_specification:
-        capacity_reservation_preference: "open" | "none"
-        capacity_reservation_target:
-          capacity_reservation_id: "cr-0123456789abcdef0"
-          capacity_reservation_resource_group_arn: "arn:aws:resource-groups:..."
-      source_dest_check: true | false
-      disable_api_termination: true | false
-      disable_api_stop: true | false
-      instance_initiated_shutdown_behavior: "stop" | "terminate"
-      placement_group: "placement-group"
-      tenancy: "default" | "dedicated"
-      host_id: "h-0123456789abcdef0"             # optional; used when attaching to an existing dedicated host
-      backup:
-        enabled: true | false                     # defaults to false
-        only_tag: true | false                    # defaults to true
-        schedule: hourly | daily | weekly | monthly # defaults to daily; used for the 'aws-backup-schedule' tag
-      extra_tags: { "env": "dev" }                # additional tags for the instance
-      volume_extra_tags: { "tier": "gold" }       # additional tags for EBS volumes
-    ```
-
-  timeouts: (map, optional)
-    - The timeouts configuration for the EC2 Instance
-    - Default: {}
-
-  iam: (map, optional)
-    IAM configuration for the EC2 instance profile:
-    ```yaml
-    iam:
-      create: true | false                 # defaults to true; when true module creates role + instance profile
-      path: "/service-role/"              # optional IAM path
-      role_description: "IAM Instance Role <name>" # optional description
-      permissions_boundary: "arn:aws:iam::123456789012:policy/BoundaryPolicy" # optional
-      extra_tags: { "team": "platform" } # optional tags for IAM resources
-      role_policies:                       # optional map (name => policy ARN) to attach to the role
-        ssm: "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-      instance_profile: "existing-profile" # used only when create=false to use an existing instance profile
-    ```
-
-  Example of a Terragrunt configuration referencing this module (terragrunt.hcl):
+  # 2. Scaffold the module (do NOT use --working-dir)
+  terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-ec2-instances
+  
+  # 3. Edit inputs.yaml with deployment-specific values
+  #    (all keys and comments are pre-populated from .boilerplate/inputs.yaml)
+  vi inputs.yaml
+  
+  # 4. Review the execution plan
+  terragrunt plan
+  
+  # 5. Apply
+  terragrunt apply
+  ```
+  
+  The scaffolded `inputs.yaml` contains only module-specific variables. The Terragrunt hierarchy provides `org`, `is_hub`, `spoke_def`, and merged `extra_tags` automatically.
+  
+  Generated `inputs.yaml`:
+  
+  ```yaml
+  # Module configuration
+  # Module-specific inputs only. Terragrunt hierarchy/scaffold supplies org, is_hub, spoke_def, and extra_tags.
+  
+  name: "" # (Optional) Exact EC2 instance name. Set this or name_prefix. Default: "".
+  name_prefix: "" # (Optional) Prefix used to derive the final instance name with the module naming convention. Default: "".
+  
+  instance:
+    create: true # (Optional) Create the EC2 instance resources. Default: true.
+    create_spot: false # (Optional) Launch a Spot instance instead of an on-demand instance. Default: false.
+    ignore_ami_changes: false # (Optional) Ignore subsequent AMI drift after the first create. Default: false.
+    type: "t3.micro" # (Required when instance.create=true) EC2 instance type. Example: "t3.micro". No module default.
+    availability_zone: null # (Optional) Availability Zone for the instance and dedicated host resources. Default: null.
+    hibernation: null # (Optional) Enable EC2 hibernation when the AMI and instance type support it. Default: null.
+    monitoring: null # (Optional) Enable detailed CloudWatch monitoring. Default: null.
+    get_password_data: null # (Optional) Retrieve Windows password data. Default: null.
+    user_data: null # (Optional) Plain-text user data. Default: null.
+    user_data_base64: null # (Optional) Base64-encoded user data. Default: null.
+    user_data_file: null # (Optional) Local file path to base64-encode when using the AMI-ignore workflow. Default: null.
+    user_data_replace_on_change: null # (Optional) Recreate the instance when user data changes. Default: null.
+    source_dest_check: null # (Optional) Enable or disable source/destination checks. Default: null.
+    disable_api_termination: null # (Optional) Protect the instance from API termination. Default: null.
+    disable_api_stop: null # (Optional) Protect the instance from API stop actions. Default: null.
+    instance_initiated_shutdown_behavior: null # (Optional) Behavior after an in-guest shutdown. Valid values: "stop", "terminate". Default: null.
+    placement_group: null # (Optional) Existing placement group name. Default: null.
+    tenancy: null # (Optional) Tenancy model. Valid values: "default", "dedicated", "host". Default: null.
+    host_id: null # (Optional) Existing dedicated host ID to reuse when dedicated_host.enabled=false. Default: null.
+    cpu_credits: null # (Optional) CPU credits mode for burstable families. Valid values: "standard", "unlimited". Default: null.
+    extra_tags: {} # (Optional) Additional tags merged into instance tags. Default: {}.
+    volume_extra_tags: {} # (Optional) Additional tags merged into EBS volume tags. Default: {}.
+    secrets_manager_enabled: true # (Optional) Store generated key material in AWS Secrets Manager when key_pair.create=true. Default: true.
+  
+    ami:
+      name: null # (Optional) AMI name lookup. When set, it takes precedence over ami.id. Default: null.
+      id: null # (Optional) Explicit AMI ID. Use this when ami.name is not set. Default: null.
+      architecture: "x86_64" # (Optional) AMI architecture filter for name-based lookups. Common values: "x86_64", "arm64". Default: "x86_64".
+      most_recent: true # (Optional) Select the newest AMI that matches the filters. Default: true.
+      owners: ["self"] # (Optional) AWS account IDs or aliases allowed to own the selected AMI. Default: ["self"].
+      filters: [] # (Optional) Additional aws_ami filters; each item supports name and values. Default: [].
+  
+    spot:
+      price: null # (Optional) Maximum Spot price. Default: null.
+      type: "one-time" # (Optional) Spot request type. Valid values: "one-time", "persistent". Default: "one-time".
+      instance_interruption_behavior: null # (Optional) Spot interruption behavior. Valid values: "terminate", "stop", "hibernate". Default: null.
+      valid_until: null # (Optional) RFC3339 expiration timestamp for the Spot request. Default: null.
+  
+    dedicated_host:
+      enabled: false # (Optional) Create a dedicated host for non-Spot launches. Default: false.
+      instance_family: null # (Optional) Dedicated host instance family. When null, the module derives it from instance.type. Default: null.
+      host_recovery: null # (Optional) Dedicated host recovery setting. Default: null.
+      auto_placement: null # (Optional) Dedicated host auto placement. Valid values: "on", "off". Default: null.
+  
+    key_pair:
+      create: false # (Optional) Generate and register a new AWS key pair. Default: false.
+      name: null # (Optional) Existing or generated key pair name. When create=true and omitted, the module derives the name. Default: null.
+  
+    cpu_options:
+      core_count: null # (Optional) Number of CPU cores. Default: null.
+      threads_per_core: null # (Optional) Threads per CPU core. Default: null.
+      amd_sev_snp: null # (Optional) Enable AMD SEV-SNP when supported. Default: null.
+  
+    vpc:
+      subnet_id: null # (Required when creating the instance or a managed ENI/security group) Target subnet ID. Default: null.
+      security_group_ids: [] # (Optional) Existing security groups to attach, in addition to a managed security group when enabled. Default: [].
+      associate_public_ip_address: null # (Optional) Assign a public IPv4 address on launch. Default: null.
+      public_eip_id: "" # (Optional) Existing Elastic IP allocation ID to associate after launch when associate_public_ip_address=false. Default: "".
+      private_ip: null # (Optional) Primary private IPv4 address. Default: null.
+      secondary_private_ips: [] # (Optional) Additional private IPv4 addresses. Default: [].
+      ipv6_address_count: null # (Optional) Number of IPv6 addresses to assign. Default: null.
+      ipv6_addresses: [] # (Optional) Explicit IPv6 addresses to assign. Default: [].
+  
+    security_group:
+      create: false # (Optional) Create a dedicated security group in the instance subnet VPC. Default: false.
+      rules: {} # (Optional) Map of rule objects. Each rule supports description, type, from_port, to_port, protocol, cidr_blocks, ipv6_cidr_blocks, self, source_security_group, and source_security_group_id. Default: {}.
+  
+    network_interface:
+      create: false # (Optional) Create and attach a managed ENI. Default: false.
+      subnet_id: null # (Required when network_interface.create=true) Subnet for the managed ENI. Default: null.
+      private_ips: [] # (Optional) Static private IPv4 addresses for the managed ENI. Default: [].
+      delete_on_termination: null # (Optional) Delete an attached existing ENI on instance termination when create=false. Default: null.
+      network_interface_id: null # (Optional) Existing ENI ID to attach when network_interface.create=false. Default: null.
+  
+    root_block_device:
+      volume_size: null # (Optional) Root volume size in GiB. Default: null.
+      volume_type: null # (Optional) Root volume type. Example: "gp3". Default: null.
+      iops: null # (Optional) Root volume provisioned IOPS. Default: null.
+      throughput: null # (Optional) Root volume throughput in MiB/s. Default: null.
+      encrypted: null # (Optional) Encrypt the root volume. Default: null.
+      kms_key_id: null # (Optional) KMS key ID or ARN for root volume encryption. Default: null.
+      delete_on_termination: null # (Optional) Delete the root volume when the instance is terminated. Default: null.
+      tags: {} # (Optional) Additional tags for the root volume. Default: {}.
+  
+    ebs:
+      ebs_optimized: null # (Optional) Enable EBS optimization when supported by the instance type. Default: null.
+      block_device: [] # (Optional) Additional EBS volumes. Each item supports device_name and optional delete_on_termination, encrypted, iops, kms_key_id, snapshot_id, volume_size, volume_type, throughput, and tags. Default: [].
+  
+    ephemeral_block_device: [] # (Optional) Ephemeral devices. Each item supports device_name and optional virtual_name and no_device. Default: [].
+  
+    metadata_options:
+      http_endpoint: null # (Optional) IMDS endpoint state. Valid values: "enabled", "disabled". Default: null.
+      http_put_response_hop_limit: null # (Optional) IMDS hop limit. Default: null.
+      http_tokens: null # (Optional) IMDS token requirement. Valid values: "optional", "required". Default: null.
+      instance_metadata_tags: null # (Optional) Expose tags through IMDS. Valid values: "enabled", "disabled". Default: null.
+  
+    private_dns_name_options:
+      hostname_type: null # (Optional) Private DNS hostname type. Valid values: "ip-name", "resource-name". Default: null.
+      enable_resource_name_dns_a_record: null # (Optional) Publish A record for the resource name. Default: null.
+      enable_resource_name_dns_aaaa_record: null # (Optional) Publish AAAA record for the resource name. Default: null.
+  
+    maintenance_options:
+      auto_recovery: null # (Optional) EC2 auto recovery behavior. Valid values: "default", "disabled". Default: null.
+  
+    enclave_options:
+      enabled: null # (Optional) Enable Nitro Enclaves. Default: null.
+  
+    capacity_reservation_specification:
+      capacity_reservation_preference: null # (Optional) Capacity reservation preference. Valid values: "open", "none". Default: null.
+      capacity_reservation_target:
+        capacity_reservation_id: null # (Optional) Capacity reservation ID. Default: null.
+        capacity_reservation_resource_group_arn: null # (Optional) Capacity reservation resource group ARN. Default: null.
+  
+    backup:
+      enabled: false # (Optional) Apply AWS Backup tagging. Default: false.
+      only_tag: true # (Optional) Only tag the instance for backup selection. Default: true.
+      schedule: "daily" # (Optional) Backup schedule tag. Valid values: "hourly", "daily", "weekly", "monthly". Default: "daily".
+  
+  timeouts:
+    create: null # (Optional) Terraform create timeout, for example "30m". Default: null.
+    update: null # (Optional) Terraform update timeout, for example "30m". Default: null.
+    delete: null # (Optional) Terraform delete timeout, for example "30m". Default: null.
+  
+  iam:
+    create: true # (Optional) Create an IAM role and instance profile for the instance. Default: true.
+    instance_profile: null # (Optional) Existing IAM instance profile to use when iam.create=false. Default: null.
+    path: null # (Optional) IAM path for created role and instance profile. Default: null.
+    role_description: null # (Optional) Custom description for the created IAM role. Default: null.
+    permissions_boundary: null # (Optional) IAM permissions boundary ARN for the created role. Default: null.
+    extra_tags: {} # (Optional) Additional tags for IAM resources. Default: {}.
+    role_policies: {} # (Optional) Map of managed policy attachments where the value is a policy ARN. Default: {}.
+    policies: [] # (Optional) Inline IAM policies to create. Each item supports name and statements; statements support sid, effect, actions, resources, principals { type, identifiers }, and conditions { test, variable, values }. Default: [].
+  ```
+  
+  Generated `terragrunt.hcl`:
+  
   ```hcl
-  terraform {
-    source = "git::https://github.com/cloudopsworks/terraform-module-aws-ec2-instances.git//?ref=develop"
+  locals {
+    local_vars  = yamldecode(file("./inputs.yaml"))
+    spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
+    region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
+    env_vars    = yamldecode(file(find_in_parent_folders("env-inputs.yaml")))
+    global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
+  
+    local_tags  = jsondecode(file("./local-tags.json"))
+    spoke_tags  = jsondecode(file(find_in_parent_folders("spoke-tags.json")))
+    region_tags = jsondecode(file(find_in_parent_folders("region-tags.json")))
+    env_tags    = jsondecode(file(find_in_parent_folders("env-tags.json")))
+    global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
+  
+    tags = merge(
+      local.global_tags,
+      local.env_tags,
+      local.region_tags,
+      local.spoke_tags,
+      local.local_tags
+    )
   }
-
+  
+  include "root" {
+    path = find_in_parent_folders("root.hcl")
+  }
+  
+  terraform {
+    source = "github.com/cloudopsworks/terraform-module-aws-ec2-instances"
+  }
+  
   inputs = {
-    org = {
-      organization_name = "acme"
-      organization_unit = "platform"
-      environment_type  = "nonprod"
-      environment_name  = "dev"
-    }
-
-    name = "my-instance"
-
-    instance = {
-      create = true
-      type   = "t3.micro"
-
-      ami = {
-        name   = "my-custom-ami"
-        owners = ["self"]
-      }
-
-      key_pair = {
-        create = false
-        name   = "my-existing-key"
-      }
-
-      vpc = {
-        subnet_id          = "subnet-123456"
-        security_group_ids = ["sg-123456"]
-      }
-
-      # Optionally let module create and manage a security group with rules:
-      # security_group = {
-      #   create = true
-      #   rules = {
-      #     ssh = {
-      #       type        = "ingress"
-      #       from_port   = 22
-      #       to_port     = 22
-      #       protocol    = "tcp"
-      #       cidr_blocks = ["0.0.0.0/0"]
-      #     }
-      #   }
-      # }
-    }
-
-    # By default, the module creates an IAM role and instance profile (iam.create = true).
-    # To use an existing instance profile instead:
-    iam = {
-      create           = false
-      instance_profile = "my-existing-profile"
-    }
+    is_hub      = false
+    org         = local.env_vars.org
+    spoke_def   = local.spoke_vars.spoke_def
+    name        = try(local.local_vars.name, "")
+    name_prefix = try(local.local_vars.name_prefix, "")
+    instance    = try(local.local_vars.instance, {})
+    timeouts    = try(local.local_vars.timeouts, {})
+    iam         = try(local.local_vars.iam, {})
+    extra_tags  = local.tags
   }
   ```
 
 # Example usage
 examples: |-
-  Here are sample use cases you can adapt in the .boilerplate files on the "develop" branch:
+  Common deployment patterns for this module include:
   
-  1. Single Development Instance
-     - Minimal inputs to spin up a small on-demand instance for dev/testing.
-  
-  2. Spot Instance for Cost Optimization
-     - Set instance.create_spot = true to request spot capacity with the same configuration.
-  
-  3. Dedicated Host Placement
-     - Set instance.dedicated_host.enabled = true to launch on a dedicated host (supported for the type). Optionally set instance.dedicated_host.instance_family or use host_id to attach to an existing host.
-  
-  4. Private Subnet Deployment
-     - Provide instance.vpc.subnet_id and security_group_ids; omit public IP or set associate_public_ip_address = false.
-  
-  5. Custom Storage and Metadata
-     - Use instance.root_block_device or instance.ebs.block_device for volumes, and instance.metadata_options to enforce IMDSv2.
-  
-  For more Terragrunt-based examples and structural hints, see the .boilerplate directory in the "develop" branch.
+  1. **Small on-demand instance**
+     - Set `instance.type`, choose `ami.name` or `ami.id`, and provide `instance.vpc.subnet_id`.
+  2. **Spot capacity for cost-sensitive workloads**
+     - Set `instance.create_spot = true` and tune `instance.spot.price`, `instance.spot.type`, and `instance.spot.instance_interruption_behavior`.
+  3. **Managed access layer**
+     - Enable `instance.key_pair.create`, keep `instance.secrets_manager_enabled = true`, and add `iam.role_policies` such as `AmazonSSMManagedInstanceCore`.
+  4. **Dedicated host placement**
+     - Set `instance.dedicated_host.enabled = true` for non-Spot launches, or provide `instance.host_id` to reuse an existing host.
+  5. **Private subnet with controlled ingress**
+     - Set `instance.vpc.associate_public_ip_address = false`, attach existing security groups through `instance.vpc.security_group_ids`, or enable `instance.security_group.create` and define explicit rules.
 
 # How to get started quickly
 quickstart: |-
-  1. Clone or fork the repository to review the .boilerplate templates under the "develop" branch.
-  2. Adapt the relevant Terragrunt configuration files for your own environment by referencing this module.
-  3. Initialize your workspace using terragrunt init.
-  4. Review proposed infrastructure changes by running terragrunt plan.
-  5. Finally, configure and deploy your EC2 instances with terragrunt apply.
+  1. From your environment stack, create a directory for the EC2 deployment.
+  2. Run `terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-ec2-instances` inside that directory.
+  3. Fill in `inputs.yaml`, making sure `instance.type`, AMI selection, and subnet details are set.
+  4. Run `terragrunt plan` and review the proposed EC2, IAM, networking, and storage resources.
+  5. Apply with `terragrunt apply` once the plan matches the desired deployment.
 
 include:
   - "docs/targets.md"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.11.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.11.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary

- restore `.boilerplate/inputs.yaml` as the authoritative module-specific scaffold input template
- sync scaffolded Terragrunt docs and generated README output with the hierarchy-driven contract
- fix `spoke_def` mapping in the scaffold template and narrow the post-scaffold git staging hook

+semver: patch